### PR TITLE
Handle empty list objects in as.Node.list

### DIFF
--- a/R/node_conversion_list.R
+++ b/R/node_conversion_list.R
@@ -106,7 +106,7 @@ as.Node.list <- function(x, mode = c("simple", "explicit"), nameName = "name", c
   
   #children
   if (is.character(x)) return (n)
-  if (mode == 'simple') children <- x[sapply(x, is.list)]
+  if (mode == 'simple') children <- x[vapply(x, is.list, logical(1))]
   else if (mode == 'explicit') children <- x[[childrenName]]
   
   if (length(children) == 0) return (n)

--- a/tests/testthat/test-treeConversion.R
+++ b/tests/testthat/test-treeConversion.R
@@ -222,6 +222,14 @@ children:
 })
 
 
+test_that("as.Node.list empty list()", {
+  lol = list(a = list(aa=1), b="hello", c = list())
+  tree = FromListSimple(lol)
+  expect_equal(tree$totalCount, 3)
+  expect_equal(tree$height, 2)
+  expect_equal(tree$c$count, 0)
+  expect_equal(tree$c$fields, character(0))
+})
 
 
 


### PR DESCRIPTION
Empty lists now become empty nodes. Closes #59.