### PR TITLE
Allow the possibility to keep only some fields when converting to list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,13 +27,13 @@ Suggests:
     partykit,
     foreach
 Enhances: 
-Description: Create tree structures from hierarchical data, and traverse
-    the tree in various orders. Aggregate, cumulate, print, plot, convert to and from
-    data.frame and more. Useful for decision trees, machine learning,
-    finance, conversion from and to JSON, and many other applications.
+Description: Create tree structures from hierarchical data, and traverse the
+    tree in various orders. Aggregate, cumulate, print, plot, convert to and from
+    data.frame and more. Useful for decision trees, machine learning, finance,
+    conversion from and to JSON, and many other applications.
 License: GPL (>= 2)
 URL: http://github.com/gluc/data.tree
 BugReports: http://github.com/gluc/data.tree/issues
 Depends:
     R (>= 3.0)
-RoxygenNote: 5.0.1
+RoxygenNote: 5.0.1.9000

--- a/man/as.list.Node.Rd
+++ b/man/as.list.Node.Rd
@@ -8,12 +8,12 @@
 \usage{
 \method{as.list}{Node}(x, mode = c("simple", "explicit"), unname = FALSE,
   nameName = ifelse(unname, "name", ""), childrenName = "children",
-  rootName = "", ...)
+  rootName = "", keepOnly = NULL, ...)
 
-ToListSimple(x, nameName = "name")
+ToListSimple(x, nameName = "name", ...)
 
 ToListExplicit(x, unname = FALSE, nameName = ifelse(unname, "name", ""),
-  childrenName = "children")
+  childrenName = "children", ...)
 }
 \arguments{
 \item{x}{The Node to convert}
@@ -31,7 +31,9 @@ an array rather than named objects.}
 
 \item{rootName}{The name of the node. If provided, this overrides \code{Node$name}}
 
-\item{...}{Additional parameters (ignored)}
+\item{keepOnly}{A character vector of fields to include in the result. If \code{NULL} (the default), all fields are kept.}
+
+\item{...}{Additional parameters passed to \code{as.list.Node}}
 }
 \description{
 Convert a \code{data.tree} structure to a list-of-list structure
@@ -40,6 +42,7 @@ Convert a \code{data.tree} structure to a list-of-list structure
 data(acme)
 
 str(ToListSimple(acme))
+str(ToListSimple(acme, keepOnly = "cost"))
 
 str(ToListExplicit(acme))
 str(ToListExplicit(acme, unname = TRUE))

--- a/tests/testthat/test-treeConversion.R
+++ b/tests/testthat/test-treeConversion.R
@@ -83,6 +83,20 @@ test_that("as.list.Node simple nameName=name", {
   
 })
 
+test_that("as.list.Node simple keepOnly=p", {
+  
+  data(acme)
+  l <- as.list(acme, keepOnly = 'p')
+  
+  expect_equal("list", class(l))
+  expect_equal(length(l), 4)
+  expect_equal(names(l), c('name', "Accounting", "Research", "IT"))
+  expect_equal(names(l$Research), c("New Product Line", "New Labs" ))
+  expect_equal(0.9, l$Research$`New Labs`$p)
+  expect_null(l$Research$`New Labs`$cost)
+  
+})
+
 test_that("as.list.Node explicit nameName=id", {
   
   
@@ -151,7 +165,7 @@ test_that("as.Node.list warning", {
   lol <- list(type = "Root", list(type = "Rule", count = 1), list(type = "Rule", count = 2))
   #tree <- FromListSimple(lol, nameName = NULL, nodeName = 1)
   tree <- NULL
-  expect_that(FromListSimple(lol, nameName = NULL, nodeName = 1, check = "no-warn"), not(gives_warning()))
+  expect_warning(FromListSimple(lol, nameName = NULL, nodeName = 1, check = "no-warn"), NA)
   expect_that(tree <- FromListSimple(lol, nameName = NULL, nodeName = 1), gives_warning())
   
   expect_equal(tree$totalCount, 3)
@@ -160,7 +174,7 @@ test_that("as.Node.list warning", {
   expect_equal(unname(tree$Get("count")), c(2,0,0))
   expect_equal(unname(tree$Get("count2")), c(NA, 1, 2))
   
-  expect_that(FromListSimple(lol, nameName = NULL, nodeName = 1, check = "no-check"), not(gives_warning()))
+  expect_warning(FromListSimple(lol, nameName = NULL, nodeName = 1, check = "no-check"), NA)
   expect_that(tree <- FromListSimple(lol, nameName = NULL, nodeName = 1), gives_warning())
   
   

--- a/tests/testthat/test-treeConversionDataFrame.R
+++ b/tests/testthat/test-treeConversionDataFrame.R
@@ -28,10 +28,10 @@ test_that("FromDataFrameTable reserved words", {
   df <- data.frame(pathString, value, stringsAsFactors = FALSE)
 
   #no warn
-  expect_that(tree <- FromDataFrameTable(df, na.rm = TRUE), not(gives_warning()))
+  expect_warning(tree <- FromDataFrameTable(df, na.rm = TRUE), NA)
   expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
   
-  expect_that(tree <- FromDataFrameTable(df, na.rm = TRUE, check = "no-warn"), not(gives_warning()))
+  expect_warning(tree <- FromDataFrameTable(df, na.rm = TRUE, check = "no-warn"), NA)
   expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
 
   #reserved words
@@ -42,7 +42,7 @@ test_that("FromDataFrameTable reserved words", {
   expect_equal(Get(tree$leaves, "value"), c(count2 = "d", e = "e", leaves2 = "f"))
   
   df <- data.frame(pathString, value, stringsAsFactors = FALSE)
-  expect_that(tree <- FromDataFrameTable(df, na.rm = TRUE, check = "no-warn"), not(gives_warning()))
+  expect_warning(tree <- FromDataFrameTable(df, na.rm = TRUE, check = "no-warn"), NA)
   expect_equal(Get(tree$leaves, "value"), c(count2 = "d", e = "e", leaves2 = "f"))
   
 


### PR DESCRIPTION
Hi,

This PR adds a parameter to subset the fields when converting a Node to a list. I also added the relevant tests and fixed some of the existing ones (`not()` is deprecated in `testthat` and is firing a warning)