### PR TITLE
use inherits() to assess class

### DIFF
--- a/R/node_conversion_list.R
+++ b/R/node_conversion_list.R
@@ -109,7 +109,7 @@ as.Node.list <- function(x, mode = c("simple", "explicit"), nameName = "name", c
   for (i in seq_along(field_nums)) {
     v <- x[[field_nums[i]]]
     
-    if(mode == 'simple' && class(v) == "list") {
+    if(mode == 'simple' && inherits(v, 'list')) {
       #any list is interpreted as child, so don't store
     } else {
       fieldNm <- fields[i]


### PR DESCRIPTION
fixes #79 

It is generally better to use `inherits()` than comparing classes with `==`. 
Unless you have a specific reason to prevent more specific objects inheriting from list to be processed.
It doesn't seems to be the case, otherwise you would have handled that situation.