### PR TITLE
make the conversion compatible with tibbles

### DIFF
--- a/R/node_conversion_dataframe.R
+++ b/R/node_conversion_dataframe.R
@@ -288,7 +288,7 @@ FromDataFrameTable <- function(table,
                                na.rm = TRUE,
                                check = c("check", "no-warn", "no-check")
                                ) {
-  table[ , pathName] <- as.character(table[ , pathName])
+  table[[pathName]] <- as.character(table[[pathName]])
   root <- NULL
   mycols <- names(table)[ !(names(table) %in% c(NODE_RESERVED_NAMES_CONST, pathName)) ]
   for (i in 1:nrow(table)) {


### PR DESCRIPTION
Hi,

If `table` is a [tibble](https://github.com/hadley/tibble), accessing `pathName` with `table[ , pathName]` does not yield a vector but a data.frame-like structure with one column:

```r
library(tibble)
x <- tibble(a = LETTERS, b = letters)
x[, "a"]
as.data.frame(x)[, "a"]
```

Casting it to character transforms it into a single character that is duplicated to the whole column when assigned back to `table[ , pathName]`. Using `[[` fixes the problem and does not change the behavior for `data.frame`s. 

```r
x[["a"]]
as.data.frame(x)[["a"]]
```

Another possibility is casting `table` to `data.frame` at the start, what do you think ?