### PR TITLE
Fix plot for a tree with a single node

### DIFF
--- a/R/node_conversion_dataframe.R
+++ b/R/node_conversion_dataframe.R
@@ -181,7 +181,7 @@ ToDataFrameNetwork <- function(x,
 
   df <- cbind(df, df2)
   df <- df[-1,]
-  rownames(df) <- 1:dim(df)[1]
+  rownames(df) <- seq_len(nrow(df))
   return (df)
 }
 

--- a/R/node_plot.R
+++ b/R/node_plot.R
@@ -109,7 +109,7 @@ ToDiagrammeRGraph <- function(root, direction = c("climb", "descend"), pruneFun 
   Set(tr, `.id` = 1:length(tr))
   
   #create nodes df
-  myargs <- NULL
+  myargs <- list()
   if(!"label" %in% ns) ns <- c(ns, "label")
   for (style in ns) {
     myargs[[style]] <- Get(tr, function(x) {
@@ -136,7 +136,9 @@ ToDiagrammeRGraph <- function(root, direction = c("climb", "descend"), pruneFun 
   
   
   edges <- do.call("ToDataFrameNetwork", c(root, from = function(node) node$parent$`.id`, to = ".id", myargs, direction = list(direction), pruneFun = pruneFun))[,-(1:2)]
-  edges <- do.call(create_edge_df, as.list(edges))
+  if (nrow(edges) > 0) {
+    edges <- do.call(create_edge_df, as.list(edges))
+  }
   
   graph <- create_graph(nodes, edges, attr_theme = NULL)
   


### PR DESCRIPTION
On the master or dev branches I cannot plot a tree containing a single node:

```
> acme <- Node$new("Acme Inc.")
> plot(acme)
Error in do.call(create_node_df, c(n = length(tr), myargs)) :
  second argument must be a list
```

This PR fixes this issue.
