### PR TITLE
Fix name setting in Get

### DIFF
--- a/R/node_methods_traversal.R
+++ b/R/node_methods_traversal.R
@@ -197,7 +197,13 @@ Get = function(nodes,
   if (is.character(attribute) && attribute == "name") {
     names(res) <- res
   } else {
-    names(res) <- Get(nodes, "name")
+    if(is.null(dim(res))){
+      names(res) <- Get(nodes, "name")
+    } else {
+      if(is.null(dimnames(res)))
+        dimnames(res) <- list()
+      dimnames(res)[[length(dim(res))]] <- Get(nodes, "name")
+    } 
   }
   if (regular) {
     res <- do.call(cbind, res)


### PR DESCRIPTION
When get returns a vector (or higher dimensional) attribute `sapply` with `simplify = TRUE` returns a matrix. Setting `names` of a matrix will name the individual elements sequentially, leaving addition elements unnamed. I believe the desirable behaviour in the multidimensional case is to give `dimnames` to the highest dimension.  To see the issue run

```
tr <- as.Node(list(a = list(b = list())))
tr$Do(function(n) n$val <- 1:2)
tr$Get("val")
```

and observe

```
     [,1] [,2] [,3]
[1,]    1    1    1
[2,]    2    2    2
attr(,"names")
[1] "Root" "a"    "b"    NA     NA     NA    
```

vs after the change

```
     Root a b
[1,]    1 1 1
[2,]    2 2 2
```