### PR TITLE
Fix as.data.frame.Node to properly handle list fields

### DIFF
--- a/R/node_conversion_dataframe.R
+++ b/R/node_conversion_dataframe.R
@@ -110,7 +110,7 @@ as.data.frame.Node <- function(x,
                    }
                 )
     }
-    df[colName] <- it
+    df[colName] <- unlist(it)
 
   }
 

--- a/R/node_conversion_dataframe.R
+++ b/R/node_conversion_dataframe.R
@@ -100,12 +100,13 @@ as.data.frame.Node <- function(x,
       it <- Get(t, 
                 col,
                 format = format, 
-                inheritFromAncestors = inheritFromAncestors)
-      it <- sapply(it, 
+                inheritFromAncestors = inheritFromAncestors,
+                simplify = FALSE)
+      it <- lapply(it, 
                    function(el) {
                           if (inherits(el, "Node")) return ("")
-                          else if (length(el) > 1) return (toString(el))
-                          else if (length(el) == 0) return (NA)
+                          else if (length(unlist(el)) > 1) return (toString(unlist(el)))
+                          else if (length(unlist(el)) == 0) return (NA)
                           else return (el)
                    }
                 )

--- a/tests/testthat/test-treeConversionDataFrame.R
+++ b/tests/testthat/test-treeConversionDataFrame.R
@@ -76,6 +76,16 @@ test_that("as.data.frame.Node", {
   expect_equal(acmedf$sg, acmedf$sg)
 })
 
+test_that("as.data.frame.Node list fields", {
+  data(acme)
+  acme$Set(data      = list(list(list(a = 1, b = "a"))), filterFun = isLeaf)
+  acme$Set(data      = list(list(list(b = "c"))), 
+           filterFun = function(n) isNotLeaf(n) && isNotRoot(n))
+  expect_identical(as.data.frame(acme, data = "data")$data,
+                   c(NA, "c", "1, a", "1, a", "c", "1, a", "1, a", "c", "1, a", 
+                     "1, a", "1, a"))
+})
+
 
 test_that("ToDataFrameTable", {
   data(acme)


### PR DESCRIPTION
This PR fixes #135. Problem was that `sapply` may return a list (and **not** a vector) and `Get` may return a matrix. Needed to add some `unlist`s here and there.