### PR TITLE
Fix plot of tree with quotation marks

### DIFF
--- a/R/node_plot.R
+++ b/R/node_plot.R
@@ -126,6 +126,9 @@ ToDiagrammeRGraph <- function(root, direction = c("climb", "descend"), pruneFun 
   
   nodes <- do.call(create_node_df, c(n = length(tr), myargs))
   
+  ## escape quotes in names to avoid problems with the gviz
+  nodes$label <- gsub("\"", "\\\\\"", nodes$label)
+
   # get unique edge styles
   
   es <- unique(unlist(sapply(root$Get(function(x) attr(x, "edgeStyle"), simplify = FALSE), names)))

--- a/tests/testthat/test-draw.R
+++ b/tests/testthat/test-draw.R
@@ -106,19 +106,11 @@ test_that("grViz single attribute names not uniuqe", {
   
 })
 
-<<<<<<< HEAD
 test_that("grViz names with quotes", {
   mytree <- Node$new("my_root")
   mytree$AddChild("A")$AddChild("\"B\"")$AddChild("\"C\"")$AddChild("D")
   exp_lab <- c("my_root", "A", "\\\"B\\\"", "\\\"C\\\"", "D")
   expect_equal(ToDiagrammeRGraph(mytree)$nodes_df$label,
-=======
-testthat("grViz names with quotes", {
-  mytree <- Node$new("my_root")
-  mytree$AddChild("A")$AddChild("\"B\"")$AddChild("\"C\"")$AddChild("D")
-  exp_lab <- c("my_root", "A", "\\\"B\\\"", "\\\"C\\\"", "D")
-  expect_equal(ToDiagrammeRGraph(behaveData)$nodes_df$label,
->>>>>>> b1fc955d8067df5f570b53616666c3429ae2c39b
                exp_lab)
 })
 

--- a/tests/testthat/test-draw.R
+++ b/tests/testthat/test-draw.R
@@ -106,3 +106,11 @@ test_that("grViz single attribute names not uniuqe", {
   
 })
 
+test_that("grViz names with quotes", {
+  mytree <- Node$new("my_root")
+  mytree$AddChild("A")$AddChild("\"B\"")$AddChild("\"C\"")$AddChild("D")
+  exp_lab <- c("my_root", "A", "\\\"B\\\"", "\\\"C\\\"", "D")
+  expect_equal(ToDiagrammeRGraph(mytree)$nodes_df$label,
+               exp_lab)
+})
+


### PR DESCRIPTION
Escape quotes in names to allow the underlying render_graph function
to properly display the graph.

Node names which contain quotation marks resulted in invalid
strings in the graphviz representation. Escaping those remedied
this issue.

Fixes: #137