### PR TITLE
Adding reserved word check to FromDataFrameNetwork

### DIFF
--- a/R/node_conversion_dataframe.R
+++ b/R/node_conversion_dataframe.R
@@ -409,6 +409,7 @@ FromDataFrameNetwork <- function(network, check = c("check", "no-warn", "no-chec
           vlu <- network[idx, j]
           if (!is.na(vlu)) {
             nm <- names(network)[j]
+            nm <- CheckNameReservedWord(nm, check)
             if (!nm %in% NODE_RESERVED_NAMES_CONST) child[[nm]] <- network[idx, j]
           }
         }

--- a/tests/testthat/test-treeConversionDataFrame.R
+++ b/tests/testthat/test-treeConversionDataFrame.R
@@ -70,14 +70,13 @@ test_that("FromDataFrameNetwork reserved words", {
   network_df <- data.frame(parent, child, value, stringsAsFactors = FALSE)
   
   #no warn
-  expect_warning(tree <- FromDataFrameNetwork(network_df), NA)
-  expect_warning(tree <- FromDataFrameTable(df, na.rm = TRUE, check = "no-warn"), NA)
+  expect_warning(tree <- FromDataFrameNetwork(network_df), regexp = NA)
   
   #reserved words
-  name <- c("a", "a", "b", "c", "c")
-  path <- c("b", "f", "c", "d", "e")
-  value <- c("b", "c", "d", "e", "f")
-  network_df <- data.frame(name, path, value, stringsAsFactors = FALSE)
+  parent <- c("a", "a", "b", "c", "c")
+  child <- c("b", "f", "c", "d", "e")
+  name <- c(0:4)
+  network_df <- data.frame(parent, child, name, stringsAsFactors = FALSE)
   expect_that(tree <- FromDataFrameNetwork(network_df), gives_warning())
   expect_warning(tree <- FromDataFrameNetwork(network_df, check = "no-warn"), NA)
 })

--- a/tests/testthat/test-treeConversionDataFrame.R
+++ b/tests/testthat/test-treeConversionDataFrame.R
@@ -61,7 +61,7 @@ test_that("FromDataFrameTable reserved words", {
 })
 
 
-test_that("FromDataFrameTable reserved words", {
+test_that("FromDataFrameNetwork reserved words", {
   
   parent <- c("a", "a", "b", "c", "c")
   child <- c("b", "f", "c", "d", "e")

--- a/tests/testthat/test-treeConversionDataFrame.R
+++ b/tests/testthat/test-treeConversionDataFrame.R
@@ -61,6 +61,34 @@ test_that("FromDataFrameTable reserved words", {
 })
 
 
+test_that("FromDataFrameTable reserved words", {
+  
+  parent <- c("a", "a", "b", "c", "c")
+  child <- c("b", "f", "c", "d", "e")
+  value <- c("b", "c", "d", "e", "f")
+  
+  network_df <- data.frame(parent, child, value, stringsAsFactors = FALSE)
+  
+  #no warn
+  expect_warning(tree <- FromDataFrameNetwork(network_df), NA)
+  expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
+  
+  expect_warning(tree <- FromDataFrameTable(df, na.rm = TRUE, check = "no-warn"), NA)
+  expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
+  
+  #reserved words
+  name <- c("a", "a", "b", "c", "c")
+  path <- c("b", "f", "c", "d", "e")
+  value <- c("b", "c", "d", "e", "f")
+  network_df <- data.frame(name, path, value, stringsAsFactors = FALSE)
+  expect_that(tree <- FromDataFrameNetwork(network_df), gives_warning())
+  expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
+  
+  expect_warning(tree <- FromDataFrameNetwork(network_df, check = "no-warn"), NA)
+  expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
+})
+
+
 test_that("as.data.frame.Node", {
   data(acme)
   acmedf <- as.data.frame(acme, 

--- a/tests/testthat/test-treeConversionDataFrame.R
+++ b/tests/testthat/test-treeConversionDataFrame.R
@@ -65,16 +65,13 @@ test_that("FromDataFrameTable reserved words", {
   
   parent <- c("a", "a", "b", "c", "c")
   child <- c("b", "f", "c", "d", "e")
-  value <- c("b", "c", "d", "e", "f")
+  value <- c(0:4)
   
   network_df <- data.frame(parent, child, value, stringsAsFactors = FALSE)
   
   #no warn
   expect_warning(tree <- FromDataFrameNetwork(network_df), NA)
-  expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
-  
   expect_warning(tree <- FromDataFrameTable(df, na.rm = TRUE, check = "no-warn"), NA)
-  expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
   
   #reserved words
   name <- c("a", "a", "b", "c", "c")
@@ -82,10 +79,7 @@ test_that("FromDataFrameTable reserved words", {
   value <- c("b", "c", "d", "e", "f")
   network_df <- data.frame(name, path, value, stringsAsFactors = FALSE)
   expect_that(tree <- FromDataFrameNetwork(network_df), gives_warning())
-  expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
-  
   expect_warning(tree <- FromDataFrameNetwork(network_df, check = "no-warn"), NA)
-  expect_equal(Get(tree$leaves, "value"), c(d = "d", e = "e", f = "f"))
 })
 
 


### PR DESCRIPTION
Hi, I didn't pay attention to the "reserved words" list in data.tree when trying to convert from a dataframe (network format) to a data.tree and spent *way* too long trying to debug it. This pull request adds a check for words in the reserved list and warns if that's the case. I just implemented the already-existing `CheckNameReservedWord` from `FromDataFrameTable` with a single line of code, but added some unit tests to ensure it behaves as expected. Happy to respond if others have thoughts.