### PR TITLE
Clarify tests

### DIFF
--- a/R/node.R
+++ b/R/node.R
@@ -120,7 +120,7 @@ NODE_RESERVED_NAMES_CONST <- c(
 #' @export
 #' @format An \code{\link{R6Class}} generator object
 Node <- R6Class("Node",
-                lock_object = FALSE,
+                lock_objects = FALSE,
                 lock_class = TRUE,
                 portable = TRUE,
                 class = TRUE,

--- a/tests/testthat/test-draw.R
+++ b/tests/testthat/test-draw.R
@@ -11,6 +11,7 @@ test_that("plot only works if DiagrammeR is installed", {
   # Then
   # - an error is thrown
 
+  skip_if_not_installed("mockery")
   data(acme)
   mockery::stub(ToDiagrammeRGraph, "requireNamespace", FALSE, 1)
   mockery::stub(plot.Node, "requireNamespace", FALSE, 1)

--- a/tests/testthat/test-treeConversionApe.R
+++ b/tests/testthat/test-treeConversionApe.R
@@ -2,6 +2,7 @@ context("tree conversion ape")
 
 
 test_that("as.Node.phylo owls", {
+  skip_if_not_installed("ape")
   txt <- "owls(((Strix_aluco:4.2,Asio_otus:4.2):3.1,Athene_noctua:7.3):6.3,Tyto_alba:13.5);"
 
   p <- ape::read.tree(text = txt)
@@ -13,6 +14,7 @@ test_that("as.Node.phylo owls", {
 })
 
 test_that("as.Node.phylo height", {
+  skip_if_not_installed("ape")
   txt <- "(A:5,B:5,(C:10,D:10)E:5):0;"
   
   p <- ape::read.tree(text = txt)
@@ -24,6 +26,7 @@ test_that("as.Node.phylo height", {
 })
 
 test_that("as.Node.phylo no height", {
+  skip_if_not_installed("ape")
   txt <- "(A,B,(C,D)E)F;"
   
   p <- ape::read.tree(text = txt)
@@ -37,6 +40,7 @@ test_that("as.Node.phylo no height", {
 
 
 test_that("as.Node.phylo height non standard", {
+  skip_if_not_installed("ape")
   txt <- "(A:5,B:5,(C:10,D:10):5):0;"
   
   p <- ape::read.tree(text = txt)
@@ -50,7 +54,8 @@ test_that("as.Node.phylo height non standard", {
 
 
 test_that("as.phylo.Node heightAttributeName", {
-  
+  skip_if_not_installed("ape")
+
   data(acme)
   #needs explicit generics as library ape is not loaded
   p <- as.phylo.Node(acme)
@@ -62,7 +67,8 @@ test_that("as.phylo.Node heightAttributeName", {
 
 
 test_that("as.phylo.Node heightAttributeName", {
-
+  skip_if_not_installed("ape")
+  
   data(acme)
   height <- function(x) x$edgeHeight <- DefaultPlotHeight(x) + 1
   acme$Do(height)
@@ -98,4 +104,3 @@ test_that("GetPhyloNumber edge", {
   acme$Do(function(x) x$phyloNr <- GetPhyloNr(x, "edge"), filterFun = isNotRoot)
   expect_equal(as.vector(acme$Get("phyloNr")), c(NA, 1:10))
 })
-

--- a/tests/testthat/test-treeConversionParty.R
+++ b/tests/testthat/test-treeConversionParty.R
@@ -2,7 +2,8 @@ context("tree conversion party")
 
 
 test_that("party on", {
-  
+  skip_if_not_installed("party")
+
   airq <- subset(airquality, !is.na(Ozone))
   airct <- party::ctree(Ozone ~ ., data = airq, 
                         controls = party::ctree_control(maxsurrogate = 3))
@@ -32,6 +33,7 @@ test_that("party on", {
 
 
 test_that("partykid", {
+  skip_if_not_installed("party")
   #hack but needed, otherwise extree_data cannot be found
   library(partykit)
   airq <- subset(airquality, !is.na(Ozone))

--- a/tests/testthat/test-treeConversionRpart.R
+++ b/tests/testthat/test-treeConversionRpart.R
@@ -1,13 +1,8 @@
 context("tree conversion rpart")
 
-check_rpart_installed <- function() {
-  if (!suppressWarnings(require(rpart))) {
-    skip("library 'rpart' not available")
-  }
-}
-
 test_that("Conversion from rpart", {
-  check_rpart_installed()
+  skip_if_not_installed("rpart")
+
   fit  <- rpart(Kyphosis ~ Age + Number + Start, data = kyphosis)
   tree <- as.Node(fit)
   expect_equal(tree$totalCount,

--- a/tests/testthat/test-treeConversionigraph.R
+++ b/tests/testthat/test-treeConversionigraph.R
@@ -2,6 +2,8 @@ context("tree conversion igraph")
 
 
 test_that("as.Node.igraph undirected", {
+  skip_if_not_installed("igraph")
+
   data(acme)
   ig <- as.igraph.Node(acme, "p", c("level", "isLeaf"), directed = FALSE)
   #expect_true(is_hierarchical(ig))
@@ -11,12 +13,10 @@ test_that("as.Node.igraph undirected", {
 
 
 test_that("as.Node.igraph directed", {
+  skip_if_not_installed("igraph")
   data(acme)
   ig <- as.igraph.Node(acme, "p", c("level", "isLeaf"), directed = TRUE)
   #expect_true(is_hierarchical(ig))
   expect_true(igraph::is_directed(ig))
   expect_equal(igraph::gsize(ig), acme$totalCount - 1)
 })
-
-
-


### PR DESCRIPTION
While working toward #152, I do not have all the packages installed for all of the tests.  I made it so that testthat would skip the tests when packages were not installed (including using the current testthat `skip_if_not_installed()` for rpart even though it already had a custom skip function).

I will build the PR that fixes #152 on top of this so that I can confirm that all tests are passing.