### PR TITLE
Fixes aggregate issue of coercion to logical

### DIFF
--- a/R/node_methods.R
+++ b/R/node_methods.R
@@ -118,7 +118,7 @@ Aggregate = function(node,
   values <- sapply(node$children,
                    function(x) {
                      v <- GetAttribute(x, attribute, format = identity, ...)
-                     if (length(v) > 0 && !is.na(v)) return(v)
+                     if (length(v) > 0 && !any(is.na(v))) return(v)
                      Aggregate(x, attribute, aggFun, ...)
                    })
   result <- unname(aggFun(values))


### PR DESCRIPTION
Addresses issue #156

Addressing the following error:

Error in length(v) > 0 && !is.na(v) : 
  'length = 2' in coercion to 'logical(1)'

The error is demonstrated in the code below. In practice it emerges when I want to aggregate up a tree by building up a vector of previous entries.

`library(yaml)
yaml <- "
name: OS Students 2014/15
OS X:
  Yosemite:
    users: 16
  Leopard:
    users: 43
Linux:
  Debian:
    users: 27
  Ubuntu:
    users: 36
Windows:
  W7:
    users: 31
  W8:
    users: 32
  W10:
    users: 4
"

osList <- yaml.load(yaml)
osNode <- as.Node(osList)
print(osNode, "users")

osNode$Do(function(x) x$users <- Aggregate(x, "users", c), traversal = "post-order")`